### PR TITLE
Fix property access with never libhybris patch and give *-ofono access

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,68 @@
+String stashFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.dsc,*.changes,*.buildinfo,lintian.txt'
+String archiveFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.dsc,*.changes,*.buildinfo'
+
+pipeline {
+  agent any
+  stages {
+    stage('Build source') {
+      steps {
+        sh '/usr/bin/build-source.sh'
+        stash(name: 'source', includes: stashFileList)
+        cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+      }
+    }
+    stage('Build binary - armhf') {
+      steps {
+        parallel(
+          "Build binary - armhf": {
+            node(label: 'arm64') {
+              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+              unstash 'source'
+              sh '''export architecture="armhf"
+build-binary.sh'''
+              stash(includes: stashFileList, name: 'build-armhf')
+              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+            }
+
+
+          },
+          "Build binary - arm64": {
+            node(label: 'arm64') {
+              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+              unstash 'source'
+              sh '''export architecture="arm64"
+    build-binary.sh'''
+              stash(includes: stashFileList, name: 'build-arm64')
+              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+            }
+          },
+          "Build binary - amd64": {
+            node(label: 'amd64') {
+              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+              unstash 'source'
+              sh '''export architecture="amd64"
+    build-binary.sh'''
+              stash(includes: stashFileList, name: 'build-amd64')
+              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+            }
+          }
+        )
+      }
+    }
+    stage('Results') {
+      steps {
+        cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+        unstash 'build-armhf'
+        unstash 'build-arm64'
+        unstash 'build-amd64'
+        archiveArtifacts(artifacts: archiveFileList, fingerprint: true, onlyIfSuccessful: true)
+        sh '''/usr/bin/build-repo.sh'''
+      }
+    }
+    stage('Cleanup') {
+      steps {
+        cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+      }
+    }
+  }
+}

--- a/debian/apparmor-profile
+++ b/debian/apparmor-profile
@@ -63,7 +63,7 @@
     owner @{PROC}/[0-9]*/fd/ r,
     /usr/bin/getprop ix,
     /{,android/}system/build.prop r,
-    /dev/socket/property_service rw,
+    /{,dev/}socket/property_service rw,
     @{PROC}/cmdline r,
 
     # Site-specific additions and overrides. See local/README for details.
@@ -79,6 +79,9 @@
     #include <abstractions/audio>
 
     /dev/binder rw,
+
+    # Allow *-ofono access android properties
+    /{,dev/}socket/property_service rw,
 
     # TODO: move to base abstraction
     ptrace (read) peer=@{profile_name},

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+telepathy-mission-control-5 (1:5.16.3-2ubports1) xenial; urgency=medium
+
+  * debian/apparmor-profile:
+    - Allow *-ofono access to property_service
+    - Change property_service path reflect libhybris change
+  * Import to ubports
+
+ -- Marius Gripsgard <marius@ubports.com>  Tue, 29 Oct 2019 19:20:10 +0100
+
 telepathy-mission-control-5 (1:5.16.3-1ubuntu6) xenial; urgency=medium
 
   * Manually move the library files to the multiarch location. LP: #1542747.


### PR DESCRIPTION
Newer versions of libhybris uses android's property impl, this changes the socket path as this gets accessed on the android side of the lxc container, this also gives *-ofono access to android properties