### PR TITLE
Allow telepathy-ofono to link files in its attachments directory

### DIFF
--- a/debian/apparmor-profile
+++ b/debian/apparmor-profile
@@ -97,6 +97,8 @@
     # telepathy-ofono needs to store a database for tracking pending messages
     owner @{HOME}/.local/share/telepathy-ofono/  rw,
     owner @{HOME}/.local/share/telepathy-ofono/** rwk,
+    # telepathy-ofono uses QTemporaryFile, which creates hardlinks, for its attachments
+    owner @{HOME}/.local/share/telepathy-ofono/attachments/** rwkl,
 
     # for telepathy-ofono to read nuntium MMS messages
     owner @{HOME}/.local/share/nuntium/store/*.mms r,


### PR DESCRIPTION
telepathy-ofono uses QTemporaryFile when creating attachments for messages. QTemporaryFile now uses hardlinks internally, which clashes with apparmor.

This issue was not reproducible on ubp-5.1 or old canonical 4.4 devices, only android7/9 devices with apparently newer apparmor patches.

Fixes https://github.com/ubports/ubuntu-touch/issues/1670
Fixes https://github.com/ubports/ubuntu-touch/issues/1677
Fixes https://github.com/HelloVolla/ubuntu-touch-beta-tests/issues/94